### PR TITLE
Models.js failedRecords schema fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4426,7 +4426,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4841,7 +4842,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4897,6 +4899,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4940,12 +4943,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/interfaces/models.js
+++ b/src/interfaces/models.js
@@ -69,14 +69,7 @@ export const BlobMetadataModel = new Schema({
 	processingInfo: {
 		transformationError: {},
 		numberOfRecords: {type: Number, required: true, default: 0},
-		failedRecords: [new Schema({
-			record: {
-				leader: String,
-				fields: []
-			},
-			failed: Boolean,
-			messages: []
-		}, {_id: false})],
+		failedRecords: [],
 		importResults: [new Schema({
 			status: {
 				type: String,

--- a/src/interfaces/models.js
+++ b/src/interfaces/models.js
@@ -69,7 +69,14 @@ export const BlobMetadataModel = new Schema({
 	processingInfo: {
 		transformationError: {},
 		numberOfRecords: {type: Number, required: true, default: 0},
-		failedRecords: [new Schema({}, {_id: false})],
+		failedRecords: [new Schema({
+			record: {
+				leader: String,
+				fields: []
+			},
+			failed: Boolean,
+			messages: []
+		}, {_id: false})],
 		importResults: [new Schema({
 			status: {
 				type: String,

--- a/test-fixtures/blobs/update/8/expectedDb.json
+++ b/test-fixtures/blobs/update/8/expectedDb.json
@@ -18,37 +18,7 @@
   "blobmetadatas": [{
       "processingInfo": {
         "numberOfRecords": 5,
-        "failedRecords": [ 
-            {
-                "messages": [],
-                "record": {
-                    "fields": []
-                }
-            },
-            {
-                "messages": [],
-                "record": {
-                    "fields": []
-                }
-            },
-            {
-                "messages": [],
-                "record": {
-                    "fields": []
-                }
-            },
-            {
-                "messages": [],
-                "record": {
-                    "fields": []
-                }
-            },
-            {
-                "messages": [],
-                "record": {
-                    "fields": []
-                }
-            } ],
+        "failedRecords": [{}, {}, {}, {}, {}],
         "importResults": []
       },
       "state": "TRANSFORMATION_IN_PROGRESS",      

--- a/test-fixtures/blobs/update/8/expectedDb.json
+++ b/test-fixtures/blobs/update/8/expectedDb.json
@@ -18,7 +18,37 @@
   "blobmetadatas": [{
       "processingInfo": {
         "numberOfRecords": 5,
-        "failedRecords": [{},{},{},{},{}],
+        "failedRecords": [ 
+            {
+                "messages": [],
+                "record": {
+                    "fields": []
+                }
+            },
+            {
+                "messages": [],
+                "record": {
+                    "fields": []
+                }
+            },
+            {
+                "messages": [],
+                "record": {
+                    "fields": []
+                }
+            },
+            {
+                "messages": [],
+                "record": {
+                    "fields": []
+                }
+            },
+            {
+                "messages": [],
+                "record": {
+                    "fields": []
+                }
+            } ],
         "importResults": []
       },
       "state": "TRANSFORMATION_IN_PROGRESS",      


### PR DESCRIPTION
opening up failedRecords schema to accept input data

Example from blob read:
```
{
  "processingInfo": {
    "numberOfRecords": 41,
    "failedRecords": [
      {
        "record": {
          "fields": [
            {
              "tag": "003",
              "value": "FI-BTJ"
            },
          /* ... Multible fields... */
          ],
          "leader": "00000nam a22002294i 4500"
        },
        "messages": [
          {
            "description": "Checks whether the configured fields are present in the record",
            "state": "invalid",
            "messages": [
              "The following tag patterns are not present in the record tag field:  /^(020|022|024)$/"
            ]
          },
          {
            "description": "Checks whether the configured fields are present in the record",
            "state": "valid",
            "messages": []
          },
          {
            "description": "Checks that the record does not contain the configured fields",
            "state": "fixed"
          },
          {
            "description": "Handles empty fields",
            "state": "valid"
          },
          {
            "description": "Validates ISBN and ISSN values",
            "state": "valid"
          },
          {
            "description": "Checks that the record does not contain the configured subfields",
            "state": "valid"
          },
          {
            "description": "Check whether the configured fields have valid structure",
            "state": "valid"
          },
          {
            "description": "Handles invalid ending punctuation",
            "state": "fixed"
          }
        ],
        "failed": true
      },
     /* ... Multible records ... */
    ],
    "importResults": []
  },
  "state": "TRANSFORMED",
  "id": "dd103aea-999e-476f-b260-df34e8ad9a01",
  "profile": "foo",
  "contentType": "application/json",
  "creationTime": "2019-08-14T15:20:08.000+03:00",
  "modificationTime": "2019-08-14T15:20:13.000+03:00"
}
```